### PR TITLE
fix: add --no-check flag to prevent TypeScript type stripping errors in npx wrapper

### DIFF
--- a/scripts/build-npm-wrapper.js
+++ b/scripts/build-npm-wrapper.js
@@ -45,9 +45,11 @@ async function main() {
   // Find the mod.ts file (it should be in the package root)
   const modPath = join(__dirname, '..', 'mod.ts');
   
-  // Spawn Deno with the proper permissions and forward all arguments
+  // Use --no-check to skip type checking for node_modules files
+  // This prevents the type stripping error when running from npm
   const denoArgs = [
     'run',
+    '--no-check', // Skip type checking to avoid type stripping issues
     '--allow-read=.',
     '--allow-write=.',
     '--allow-net=127.0.0.1,api.openai.com,localhost:1234',


### PR DESCRIPTION
Resolves #10

This PR fixes the issue where `npx utopian@latest` fails with 'Stripping types is currently unsupported for files under node_modules' error.

## Changes
- Added `--no-check` flag to Deno command in npm wrapper
- Added explanatory comments about the fix

The `--no-check` flag tells Deno to skip type checking, which prevents the type stripping error when running TypeScript files from the node_modules directory.

Generated with [Claude Code](https://claude.ai/code)